### PR TITLE
Version 0.1.1

### DIFF
--- a/ExternalPrograms/Windows/UnityScreenSaverLauncher/UnityScreenSaverLauncher/Program.cs
+++ b/ExternalPrograms/Windows/UnityScreenSaverLauncher/UnityScreenSaverLauncher/Program.cs
@@ -54,7 +54,7 @@ namespace UnityScreenSaverLauncher
                 {
                     unityArgs = $"{unityArgs} -screen-width {primaryScreen.Bounds.Width} -screen-height {primaryScreen.Bounds.Height}";
                 }
-                return UnityMain(Process.GetCurrentProcess().Handle, nint.Zero,
+                return RunAsChildProcess(Process.GetCurrentProcess().Handle, nint.Zero,
                     unityArgs, 1);
             }
 
@@ -92,14 +92,25 @@ namespace UnityScreenSaverLauncher
         }
 
         /// <summary>
-        /// The entry point to Unity.
+        /// Run Unity Player as this process.
         /// </summary>
         /// <param name="hInstance">Instance of the parent process.</param>
         /// <param name="hPrevInstance">Unused since Win32.</param>
         /// <param name="lpCmdLine">Command line arguments.</param>
         /// <param name="nShowCmd">Prefered window mode.</param>
         /// <returns>The exit code.</returns>
-        static int UnityMain(IntPtr hInstance, IntPtr hPrevInstance, [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine, int nShowCmd)
+        [DllImport("UnityPlayer.dll")]
+        static extern int UnityMain(nint hInstance, nint hPrevInstance, [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine, int nShowCmd);
+
+        /// <summary>
+        /// Run Unity Player as a child process.
+        /// </summary>
+        /// <param name="hInstance">Instance of the parent process.</param>
+        /// <param name="hPrevInstance">Unused since Win32.</param>
+        /// <param name="lpCmdLine">Command line arguments.</param>
+        /// <param name="nShowCmd">Prefered window mode.</param>
+        /// <returns>The exit code.</returns>
+        static int RunAsChildProcess(nint hInstance, nint hPrevInstance, string lpCmdLine, int nShowCmd)
         {
             var assembly = Assembly.GetExecutingAssembly();
             string productName = assembly.GetCustomAttribute<AssemblyProductAttribute>()!.Product;

--- a/ExternalPrograms/Windows/UnityScreenSaverLauncher/UnityScreenSaverLauncher/ScreenSaverByUnity.csproj
+++ b/ExternalPrograms/Windows/UnityScreenSaverLauncher/UnityScreenSaverLauncher/ScreenSaverByUnity.csproj
@@ -22,6 +22,6 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="IF &quot;$(Configuration)&quot;==&quot;Release&quot; (&#xD;&#xA;  IF EXIST &quot;$(OutputPath)$(AssemblyName).scr&quot; DEL &quot;$(OutputPath)$(AssemblyName).scr&quot;&#xD;&#xA;  RENAME &quot;$(OutputPath)$(AssemblyName).exe&quot; &quot;$(AssemblyName).scr&quot;&#xD;&#xA;)" />
+    <Exec Command="IF &quot;$(Configuration)&quot;==&quot;Release&quot; (&#xD;&#xA;  IF EXIST &quot;$(OutputPath)$(AssemblyName).scr&quot; DEL &quot;$(OutputPath)$(AssemblyName).scr&quot;&#xD;&#xA;  RENAME &quot;$(OutputPath)$(AssemblyName).exe&quot; &quot;$(Product).scr&quot;&#xD;&#xA;)" />
   </Target>
 </Project>

--- a/ExternalPrograms/Windows/UnityScreenSaverLauncher/UnityScreenSaverLauncher/ScreenSaverByUnity.csproj
+++ b/ExternalPrograms/Windows/UnityScreenSaverLauncher/UnityScreenSaverLauncher/ScreenSaverByUnity.csproj
@@ -13,7 +13,7 @@
     <Company>TkoolerLufar</Company>
     <RootNamespace>UnityScreenSaverLauncher</RootNamespace>
     <Product>MyShaderArtScreenSaver</Product>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
+    <AssemblyVersion>0.1.1</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>portable</DebugType>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -139,9 +139,9 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.1.0
+  bundleVersion: 0.1.1
   preloadedAssets:
-  - {fileID: -8331133339951363772, guid: ffb81e97060786a40bde6605c7e3bdd8, type: 2}
+  - {fileID: 8802256007265200379, guid: ffb81e97060786a40bde6605c7e3bdd8, type: 2}
   - {fileID: 11400000, guid: 9a30c431a5533bf42813955415244d72, type: 2}
   - {fileID: 11400000, guid: 39e922e01a851d846ac83c31dc8ec5ac, type: 2}
   metroInputSource: 0


### PR DESCRIPTION
The Launcher for Windows runs as a single process during preview.

This behavior takes less overhead, fewer HWND loss, fewer crash on Screen Saver Settings window (but not complete fix).
